### PR TITLE
Use full BCP 47 locale in HTML lang attribute

### DIFF
--- a/site/js/i18n.js
+++ b/site/js/i18n.js
@@ -104,7 +104,7 @@
       var v = t(el.getAttribute('data-i18n-placeholder'));
       if (v !== el.getAttribute('data-i18n-placeholder')) el.placeholder = v;
     });
-    document.documentElement.lang = currentLocale.split('-')[0];
+    document.documentElement.lang = currentLocale;
   }
 
   /* ── Set locale and re-render ── */


### PR DESCRIPTION
## Summary

- Change `document.documentElement.lang` from `currentLocale.split('-')[0]` to `currentLocale`

## Problem

The current code strips the region subtag, setting `lang="zh"` for both `zh-CN` and `zh-TW`. Browsers use the `lang` attribute to select CJK font variants:

- `lang="zh-TW"` → Traditional Chinese fonts (e.g. Songti TC, PingFang TC)
- `lang="zh-CN"` → Simplified Chinese fonts (e.g. Songti SC, PingFang SC)

When both resolve to `lang="zh"`, the browser falls back to a single default — typically Simplified Chinese — causing Traditional Chinese pages to render with incorrect glyph variants.

The same issue affects `ja-JP` and `ko-KR`, where region subtags may influence font selection.

## Fix

Use the full BCP 47 locale code (e.g. `zh-TW`, `zh-CN`, `ja-JP`) as the `lang` attribute value. All existing locale codes in the `SUPPORTED` array are valid BCP 47 tags.

## Test plan

- [x] Select zh-TW and verify browser uses TC fonts (e.g. Songti TC, not Songti SC)
- [x] Select zh-CN and verify browser uses SC fonts
- [x] Verify other locales (en-US, ja-JP, ko-KR, etc.) are unaffected