### PR TITLE
Fix i18n key mismatches and translate new koan content

### DIFF
--- a/site/i18n/cs-CZ.json
+++ b/site/i18n/cs-CZ.json
@@ -1213,7 +1213,7 @@
     "journeyRootCauseFound": "Connection pool vyčerpán",
     "journeyRootCauseDetail": "database · orders pool",
     "rememberThis": "Pamatuješ si tohle?",
-    "completionLine1": "Prošel jsi cestou 19 koanů.",
+    "completionLine1": "Prošel jsi cestou 27 koanů.",
     "completionLine2": "Od tichého systému k systému, který mluví v metrics, traces a logs.",
     "completionLine3": "Začal jsi s tichem.",
     "completionLine4": "Teď vidíš.",

--- a/site/i18n/de-DE.json
+++ b/site/i18n/de-DE.json
@@ -1213,7 +1213,7 @@
     "journeyRootCauseFound": "Connection Pool erschöpft",
     "journeyRootCauseDetail": "database · orders Pool",
     "rememberThis": "Erinnerst du dich?",
-    "completionLine1": "Du hast den Pfad der 19 Koans beschritten.",
+    "completionLine1": "Du hast den Pfad der 27 Koans beschritten.",
     "completionLine2": "Von einem stummen System zu einem, das in Metrics, Traces und Logs spricht.",
     "completionLine3": "Du begannst mit Stille.",
     "completionLine4": "Jetzt kannst du sehen.",

--- a/site/i18n/en-US.json
+++ b/site/i18n/en-US.json
@@ -1212,7 +1212,7 @@
     "journeyRootCauseFound": "Connection pool exhausted",
     "journeyRootCauseDetail": "database \u00b7 orders pool",
     "rememberThis": "Remember this?",
-    "completionLine1": "You have walked the path of 19 koans.",
+    "completionLine1": "You have walked the path of 27 koans.",
     "completionLine2": "From a silent system to one that speaks in metrics, traces, and logs.",
     "completionLine3": "You began with silence.",
     "completionLine4": "Now you can see.",

--- a/site/i18n/es-ES.json
+++ b/site/i18n/es-ES.json
@@ -1213,7 +1213,7 @@
     "journeyRootCauseFound": "Pool de conexiones agotado",
     "journeyRootCauseDetail": "database · pool de orders",
     "rememberThis": "¿Recuerdas esto?",
-    "completionLine1": "Has recorrido el camino de 19 koans.",
+    "completionLine1": "Has recorrido el camino de 27 koans.",
     "completionLine2": "De un sistema silencioso a uno que habla en metrics, traces y logs.",
     "completionLine3": "Empezaste con el silencio.",
     "completionLine4": "Ahora puedes ver.",

--- a/site/i18n/fr-FR.json
+++ b/site/i18n/fr-FR.json
@@ -1213,7 +1213,7 @@
     "journeyRootCauseFound": "Pool de connexions épuisé",
     "journeyRootCauseDetail": "database · pool orders",
     "rememberThis": "Vous vous souvenez ?",
-    "completionLine1": "Vous avez parcouru le chemin de 19 koans.",
+    "completionLine1": "Vous avez parcouru le chemin de 27 koans.",
     "completionLine2": "D'un système silencieux à un système qui parle en metrics, traces et logs.",
     "completionLine3": "Vous avez commencé par le silence.",
     "completionLine4": "Maintenant vous pouvez voir.",

--- a/site/i18n/it-IT.json
+++ b/site/i18n/it-IT.json
@@ -1213,7 +1213,7 @@
     "journeyRootCauseFound": "Pool di connessioni esaurito",
     "journeyRootCauseDetail": "database · pool orders",
     "rememberThis": "Ricordi questo?",
-    "completionLine1": "Hai percorso il cammino di 19 koan.",
+    "completionLine1": "Hai percorso il cammino di 27 koan.",
     "completionLine2": "Da un sistema silenzioso a uno che parla con metric, trace e log.",
     "completionLine3": "Hai iniziato dal silenzio.",
     "completionLine4": "Ora puoi vedere.",

--- a/site/i18n/ja-JP.json
+++ b/site/i18n/ja-JP.json
@@ -1213,7 +1213,7 @@
     "journeyRootCauseFound": "接続プールの枯渇",
     "journeyRootCauseDetail": "database · ordersプール",
     "rememberThis": "覚えていますか？",
-    "completionLine1": "19の公案の道を歩みました。",
+    "completionLine1": "27の公案の道を歩みました。",
     "completionLine2": "沈黙したシステムから、metrics、traces、logsで語るシステムへ。",
     "completionLine3": "あなたは沈黙から始めました。",
     "completionLine4": "今、あなたは見ることができます。",

--- a/site/i18n/ko-KR.json
+++ b/site/i18n/ko-KR.json
@@ -1213,7 +1213,7 @@
     "journeyRootCauseFound": "커넥션 풀 소진",
     "journeyRootCauseDetail": "database · orders pool",
     "rememberThis": "이것을 기억하나요?",
-    "completionLine1": "19개의 koan의 길을 걸어왔어요.",
+    "completionLine1": "27개의 koan의 길을 걸어왔어요.",
     "completionLine2": "침묵하는 시스템에서 metric, trace, log로 말하는 시스템까지.",
     "completionLine3": "침묵에서 시작했어요.",
     "completionLine4": "이제 볼 수 있어요.",

--- a/site/i18n/nl-NL.json
+++ b/site/i18n/nl-NL.json
@@ -1213,7 +1213,7 @@
     "journeyRootCauseFound": "Connection pool uitgeput",
     "journeyRootCauseDetail": "database · orders pool",
     "rememberThis": "Herinner je dit?",
-    "completionLine1": "Je hebt het pad van 19 koans bewandeld.",
+    "completionLine1": "Je hebt het pad van 27 koans bewandeld.",
     "completionLine2": "Van een stil systeem naar een systeem dat spreekt in metrics, traces en logs.",
     "completionLine3": "Je begon met stilte.",
     "completionLine4": "Nu kun je zien.",

--- a/site/i18n/pt-BR.json
+++ b/site/i18n/pt-BR.json
@@ -1213,7 +1213,7 @@
     "journeyRootCauseFound": "Pool de conexões esgotado",
     "journeyRootCauseDetail": "database · pool do orders",
     "rememberThis": "Lembra disso?",
-    "completionLine1": "Você percorreu o caminho de 19 koans.",
+    "completionLine1": "Você percorreu o caminho de 27 koans.",
     "completionLine2": "De um sistema silencioso a um que fala em metrics, traces e logs.",
     "completionLine3": "Você começou com silêncio.",
     "completionLine4": "Agora você pode ver.",

--- a/site/i18n/ro-RO.json
+++ b/site/i18n/ro-RO.json
@@ -1213,7 +1213,7 @@
     "journeyRootCauseFound": "Connection pool epuizat",
     "journeyRootCauseDetail": "database · orders pool",
     "rememberThis": "Îți amintești asta?",
-    "completionLine1": "Ai parcurs drumul celor 19 koanuri.",
+    "completionLine1": "Ai parcurs drumul celor 27 koanuri.",
     "completionLine2": "De la un sistem tăcut la unul care vorbește în metrics, traces și logs.",
     "completionLine3": "Ai început cu tăcerea.",
     "completionLine4": "Acum poți vedea.",

--- a/site/i18n/sv-SE.json
+++ b/site/i18n/sv-SE.json
@@ -1213,7 +1213,7 @@
     "journeyRootCauseFound": "Connection pool uttömd",
     "journeyRootCauseDetail": "database · orders pool",
     "rememberThis": "Minns du detta?",
-    "completionLine1": "Du har vandrat genom 19 koans.",
+    "completionLine1": "Du har vandrat genom 27 koans.",
     "completionLine2": "Från ett tyst system till ett som talar i metrics, traces och loggar.",
     "completionLine3": "Du började i tystnad.",
     "completionLine4": "Nu kan du se.",

--- a/site/i18n/zh-CN.json
+++ b/site/i18n/zh-CN.json
@@ -1213,7 +1213,7 @@
     "journeyRootCauseFound": "连接池耗尽",
     "journeyRootCauseDetail": "database · orders pool",
     "rememberThis": "还记得这个吗？",
-    "completionLine1": "你已走完 19 则公案的修行之路。",
+    "completionLine1": "你已走完 27 则公案的修行之路。",
     "completionLine2": "从一个沉默的系统，到一个用 Metric、Trace 和 Log 开口说话的系统。",
     "completionLine3": "你始于沉默。",
     "completionLine4": "如今你能看见了。",

--- a/site/koans/03-metric.html
+++ b/site/koans/03-metric.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Koan 3: What is a Metric? - OpenTelemetry Koans</title>
+  <title data-i18n="koan03.pageTitle">Koan 3: What is a Metric? - OpenTelemetry Koans</title>
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="icon" type="image/png" sizes="32x32" href="../img/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="../img/favicon-16x16.png">

--- a/site/koans/04-metric-types.html
+++ b/site/koans/04-metric-types.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Koan 4: Kinds of Metrics - OpenTelemetry Koans</title>
+  <title data-i18n="koan04.pageTitle">Koan 4: Kinds of Metrics - OpenTelemetry Koans</title>
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="icon" type="image/png" sizes="32x32" href="../img/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="../img/favicon-16x16.png">

--- a/site/koans/06-trace.html
+++ b/site/koans/06-trace.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Koan 5: What is a Trace? - OpenTelemetry Koans</title>
+  <title data-i18n="koan06.pageTitle">Koan 6: What is a Trace? - OpenTelemetry Koans</title>
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="icon" type="image/png" sizes="32x32" href="../img/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="../img/favicon-16x16.png">


### PR DESCRIPTION
## Summary

The refactor in 5f24d48 and follow-up in f9f82cc introduced new koans and updated existing ones, but left several gaps in the i18n layer. This PR fixes them.

### Commit 1: Align i18n keys with HTML data-i18n references

- **Rename 21 keys** in all 13 locale files to match `data-i18n` attributes in HTML (e.g. `q1OptA` → `q1OptYes`, `insightLine1` → `insightP1`) in koans 05, 15, 19, 23
- **Add 90+ missing keys** referenced by HTML `data-i18n` or JS `i18n.t()` but absent from locale files (buttons, SVG labels, narrative text, routing controls, sort hints, feedback)

### Commit 2: Translate new koan content for all 12 non-English locales

~220-250 keys translated per locale, covering:

- **koan04** (Metric Types): updated insight (counter/gauge vs histogram)
- **koan05** (Outliers): updated zen, percentiles, averages, histogram
- **koan10** (Resources): detector and service map notes
- **koan15** (Is It All Open?): updated portability framing (Perses, PromQL, OpenSLO)
- **koan19** (Deployment Modes): agent/gateway, Kubernetes terminology
- **koan23** (Trace-Aware Routing): consistent hashing, tail sampling
- **koan26** (Correlation): log correlation and exemplar notes

### Commit 3: Fix koan15 item ordering and add missing item8

- Swap `item6` and `item7` to match HTML portable/locked annotations
- Add missing `item8` ("Vendor-specific integrations", locked)
- Add missing `koan19.q1Wrong` and `koan19.q2Wrong`
- Fix koan23 `explanationTryHash` referencing "the button above" when button is below

### Commit 4: Reorder i18n keys to match semantic grouping

Move keys appended at the end of each koan section to their logical position: items together, sort feedback near sort controls, wrong-answer feedback near their questions.

### Commit 5: Fix missing data-i18n on title tags

- Add `data-i18n` to `<title>` in koans 03, 04, 06 so pageTitle translations take effect
- Fix koan 06 fallback title showing old number (Koan 5 → Koan 6)

## Test plan

- [x] Open koan 05 in a non-EN locale and verify all buttons/labels show translated text
- [x] Open koan 15 and verify the sorting exercise has 9 items and correct portable/locked grouping
- [x] Open koan 19 and verify SVG diagram labels, K8s terms, and wrong-answer feedback render
- [x] Open koan 23 and verify routing animation labels (✓ can sample / ✗ cannot sample) render
- [x] Verify koans 03, 04, 06 show translated page titles in the browser tab
- [x] Verify en-US still works correctly
- [x] Spot-check 2-3 locales across new koans for translation quality