### PR TITLE
Fix music toggle not updating on locale change

### DIFF
--- a/site/js/progress.js
+++ b/site/js/progress.js
@@ -306,6 +306,12 @@
     langBtn.setAttribute('aria-label', t('common.changeLanguage', 'Change language'));
     tocBtn.title = t('common.tableOfContents', 'Table of Contents');
     tocBtn.setAttribute('aria-label', t('common.tableOfContents', 'Table of Contents'));
+    var musicBtn = document.querySelector('.music-toggle');
+    if (musicBtn) {
+      var musicLabel = t('common.toggleMusic', 'Toggle music');
+      musicBtn.title = musicLabel;
+      musicBtn.setAttribute('aria-label', musicLabel);
+    }
     var tocEntries = tocDrop.querySelectorAll('.toc-title');
     tocEntries.forEach(function (el, idx) {
       el.textContent = koanTitle(idx + 1);


### PR DESCRIPTION
## Summary

The music button's `title` and `aria-label` are set in `music.js` before the `i18n:ready` event fires, so they always get the English fallback value. The `i18n:ready` handler in `progress.js` refreshes all other nav controls (language picker, TOC, trophy, GitHub link, etc.) but was missing the music toggle.

Add the music toggle to the `i18n:ready` refresh so its `title`/`aria-label` updates when the user switches locale.

## Test plan

- [x] Switch to a non-EN locale and verify the music button's tooltip shows the translated text
- [x] Verify the music button still works (play/pause) after locale switch
- [x] Verify en-US tooltip remains "Toggle music"