### PR TITLE
Prevent flash of untranslated content for non-EN locales

### DIFF
--- a/site/js/i18n.js
+++ b/site/js/i18n.js
@@ -6,6 +6,17 @@
 
   var STORAGE_KEY = 'otel-koans-lang';
   var DEFAULT_LOCALE = 'en-US';
+
+  /* ── Prevent FOUC for non-EN locales ──
+     Since i18n.js loads in <head>, we can hide the body before it renders.
+     For en-US the HTML fallback text is already correct, so no hide needed. */
+  var savedLang = localStorage.getItem(STORAGE_KEY);
+  if (savedLang && savedLang !== DEFAULT_LOCALE) {
+    var s = document.createElement('style');
+    s.id = 'i18n-fouc';
+    s.textContent = 'body{opacity:0}body.i18n-ready{opacity:1;transition:opacity .15s}';
+    document.head.appendChild(s);
+  }
   var SUPPORTED = [
     { code: 'en-US', name: 'English (US)' },
     { code: 'pt-BR', name: 'Portugu\u00eas (BR)' },
@@ -105,6 +116,8 @@
       if (v !== el.getAttribute('data-i18n-placeholder')) el.placeholder = v;
     });
     document.documentElement.lang = currentLocale;
+    /* Reveal body after translations are applied (see FOUC guard above) */
+    document.body.classList.add('i18n-ready');
   }
 
   /* ── Set locale and re-render ── */


### PR DESCRIPTION
## Summary

When a non-English locale is active, the page briefly shows English fallback text from the HTML before `i18n.js` loads the translation JSON and applies it. This flash of untranslated content (FOUC) is distracting on every page navigation.

## Fix

Since `i18n.js` loads in `<head>` (before the body renders), it can act early:

1. Check `localStorage` for a saved non-EN locale
2. If found, inject `body { opacity: 0 }` immediately
3. After `applyDOM()` applies all translations, add class `i18n-ready` which fades the body in (`opacity: 1` with a 150ms transition)

English users see no change since the HTML fallback text is already correct.

## Test plan

- [x] Switch to a non-EN locale, navigate between koans — no English flash visible
- [x] Switch back to en-US — page loads instantly with no hide/fade
- [x] First visit (no localStorage) — page loads normally in English
- [x] Slow network: body stays hidden until translations load, then fades in