### PR TITLE
Fix pre-translated text not updating on locale switch in koans 3, 11, 27

### DIFF
--- a/site/koans/03-metric.html
+++ b/site/koans/03-metric.html
@@ -533,8 +533,7 @@
           eventStream.scrollTop = eventStream.scrollHeight;
 
           eventCount++;
-          var tmpl = i18n.t('koan03.eventCountTemplate');
-          eventCountEl.textContent = tmpl.replace('{count}', eventCount);
+          i18n.applyText(eventCountEl, 'koan03.eventCountTemplate', function(v) { return v.replace('{count}', eventCount); });
         }
 
         // --- Stream events with rising frequency ---

--- a/site/koans/11-semantic-conventions.html
+++ b/site/koans/11-semantic-conventions.html
@@ -875,10 +875,10 @@
         var opts = q.querySelectorAll('.nm-opt');
         var attempts = 0;
 
-        var scaffolding = [
-          i18n.t('koan11.q1Scaffold1'),
-          i18n.t('koan11.q1Scaffold2'),
-          i18n.t('koan11.q1Scaffold3')
+        var scaffoldKeys = [
+          'koan11.q1Scaffold1',
+          'koan11.q1Scaffold2',
+          'koan11.q1Scaffold3'
         ];
 
         opts.forEach(function (opt) {
@@ -909,7 +909,7 @@
               }, 2600);
             } else {
               this.classList.add('wrong');
-              fb.textContent = scaffolding[Math.min(attempts, scaffolding.length - 1)];
+              i18n.applyText(fb, scaffoldKeys[Math.min(attempts, scaffoldKeys.length - 1)]);
               fb.className = 'nm-fb nm-fb--wrong';
               attempts++;
               var self = this;

--- a/site/koans/27-the-investigation.html
+++ b/site/koans/27-the-investigation.html
@@ -1168,8 +1168,8 @@
         var cssClass = signal === 'metric' ? 'metric-btn' : signal === 'trace' ? 'trace-btn' : 'log-btn';
         btn.className = 'fp-choice-btn ' + cssClass;
         btn.dataset.signal = signal;
-        var labels = { metric: i18n.t('koan27.btnMetric'), trace: i18n.t('koan27.btnTrace'), log: i18n.t('koan27.btnLog') };
-        btn.textContent = labels[signal];
+        var labelKeys = { metric: 'koan27.btnMetric', trace: 'koan27.btnTrace', log: 'koan27.btnLog' };
+        i18n.applyText(btn, labelKeys[signal]);
         return btn;
       }
 


### PR DESCRIPTION
## Summary

Three koans had text that was translated once at page load or stored in variables using `i18n.t()`, then never updated when the user switched locale.

### koan11: scaffold hints array
Pre-translated array of wrong-answer hints. Store keys instead, translate at display time via `i18n.applyText()`.

### koan03: event count template
`var tmpl = i18n.t('koan03.eventCountTemplate')` called per event, but `textContent` set directly without `applyText`. Changed to `i18n.applyText()` with transform for the `{count}` replacement.

### koan27: signal choice buttons
`var labels = { metric: i18n.t(...), ... }` pre-translated in `makeChoiceBtn()`. Store keys instead and use `i18n.applyText()`.

## Test plan

- [ ] Koan 11: answer Q1 wrong, verify hint shows in current locale; switch locale, verify hint updates
- [ ] Koan 3: watch event counter increment, switch locale, verify template text updates
- [ ] Koan 27: verify signal choice buttons (Metric/Trace/Log) show in current locale; switch locale, verify buttons update