### PR TITLE
Preserve child elements when applyText and applyDOM update translations

### DIFF
--- a/site/js/i18n.js
+++ b/site/js/i18n.js
@@ -103,6 +103,22 @@
     return obj;
   }
 
+  /* ── Set text content without destroying child elements ── */
+  function setTextSafe(el, text) {
+    /* If the element has child elements (e.g. picker buttons),
+       only update the first text node to avoid wiping them out. */
+    if (el.firstElementChild) {
+      var textNode = el.firstChild;
+      if (textNode && textNode.nodeType === 3) {
+        textNode.nodeValue = text;
+      } else {
+        el.insertBefore(document.createTextNode(text), el.firstChild);
+      }
+    } else {
+      el.textContent = text;
+    }
+  }
+
   /* ── Helpers: set text AND mark for re-translation on locale switch.
      Optional transform(value) lets callers post-process the translated
      string (e.g. replace placeholders, concatenate). The transform is
@@ -111,7 +127,7 @@
   function applyText(el, key, transform) {
     var v = t(key);
     if (transform) v = transform(v);
-    el.textContent = v;
+    setTextSafe(el, v);
     el.setAttribute('data-i18n', key);
     el.removeAttribute('data-i18n-html');
     if (transform) el._i18nTransform = transform;
@@ -133,7 +149,7 @@
       var v = t(el.getAttribute('data-i18n'));
       if (v !== el.getAttribute('data-i18n')) {
         if (el._i18nTransform) v = el._i18nTransform(v);
-        el.textContent = v;
+        setTextSafe(el, v);
       }
     });
     document.querySelectorAll('[data-i18n-html]').forEach(function (el) {

--- a/tests/i18n-unit.test.js
+++ b/tests/i18n-unit.test.js
@@ -81,6 +81,31 @@ describe('i18n.applyText()', function () {
     window.i18n.applyText(el, 'common.check');
     expect(el.hasAttribute('data-i18n-html')).toBe(false);
   });
+
+  test('preserves child elements when updating text', function () {
+    var el = document.createElement('div');
+    el.appendChild(document.createTextNode('old text'));
+    var child = document.createElement('button');
+    child.textContent = 'Pick';
+    el.appendChild(child);
+
+    window.i18n.applyText(el, 'common.check');
+    expect(el.firstChild.nodeValue).toBe('Check');
+    expect(el.querySelector('button')).not.toBeNull();
+    expect(el.querySelector('button').textContent).toBe('Pick');
+  });
+
+  test('inserts text node when element has only child elements', function () {
+    var el = document.createElement('div');
+    var child = document.createElement('span');
+    child.textContent = 'child';
+    el.appendChild(child);
+
+    window.i18n.applyText(el, 'common.check');
+    expect(el.firstChild.nodeType).toBe(3); // TEXT_NODE
+    expect(el.firstChild.nodeValue).toBe('Check');
+    expect(el.querySelector('span')).not.toBeNull();
+  });
 });
 
 /* ══════════════════════════════════════════════════════════════════
@@ -174,6 +199,22 @@ describe('i18n.applyDOM()', function () {
 
     window.i18n.applyDOM();
     expect(el.textContent).toBe('original');
+  });
+
+  test('preserves child elements when re-translating', function () {
+    var el = document.createElement('div');
+    el.appendChild(document.createTextNode('old'));
+    var btn = document.createElement('button');
+    btn.className = 'picker';
+    btn.textContent = 'A';
+    el.appendChild(btn);
+    el.setAttribute('data-i18n', 'common.check');
+    document.body.appendChild(el);
+
+    window.i18n.applyDOM();
+    expect(el.firstChild.nodeValue).toBe('Check');
+    expect(el.querySelector('button.picker')).not.toBeNull();
+    expect(el.querySelector('button.picker').textContent).toBe('A');
   });
 });
 


### PR DESCRIPTION
## Summary

- `applyText()` and `applyDOM()` used `el.textContent` to set translated text, which destroys all child elements
- Koans 02 and 15 have translated text and picker buttons in the same parent — after a locale switch the buttons disappear and items become unclickable
- Add `setTextSafe()` helper that updates only the first text node when child elements are present, falling back to `textContent` when there are no children
- Add three unit tests covering the new behavior

## Test plan

- [x] Open koan 02, switch locale, verify A/B/C picker buttons still work
- [x] Open koan 15, switch locale, verify A/B picker buttons still work
- [x] Verify other koans' applyText behavior is unchanged
- [x] Verify no JS console errors
- [x] `npm test` passes (22 i18n unit tests including 3 new ones)